### PR TITLE
fix: Ensure focus_new is respected on `pick_win_relative`

### DIFF
--- a/nvim-winpick-core/src/win.rs
+++ b/nvim-winpick-core/src/win.rs
@@ -52,5 +52,10 @@ pub(crate) fn open_split_with(
         }
     };
     nvim_oxi::api::command(&with_pos).context("failed to run split command")?;
+    if let Some(refocus) = keep_focus_at {
+        nvim_oxi::api::set_current_win(refocus).context("failed to refocus old window")?;
+    } else {
+        nvim_oxi::api::set_current_win(window).context("failed to focus new window")?;
+    }
     Ok(())
 }


### PR DESCRIPTION
Predicting how neovim will chose its next focus on a split was more difficult than I thought, better just always ensure that the correct window is focused