### PR TITLE
fix: neovim 0.12 compatibility

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - name: Install Neovim v0.10.4
+      - name: Install Neovim v0.12.1
         uses: rhysd/action-setup-vim@v1
         with:
             neovim: true
-            version: v0.10.2
+            version: v0.12.1
       - name: Install libluajit (Linux)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libluajit-5.1-dev

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,28 +9,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
-name = "camino"
-version = "1.1.9"
+name = "autocfg"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
+ "memchr",
  "serde",
+]
+
+[[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.9"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "cargo_metadata"
-version = "0.19.2"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -39,6 +62,34 @@ dependencies = [
  "serde_json",
  "thiserror",
 ]
+
+[[package]]
+name = "cc"
+version = "1.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "integration-tests"
@@ -61,18 +112,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "mlua"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccd36acfa49ce6ee56d1307a061dd302c564eee757e6e4cd67eb4f7204846fab"
+dependencies = [
+ "bstr",
+ "either",
+ "libc",
+ "mlua-sys",
+ "mlua_derive",
+ "num-traits",
+ "parking_lot",
+ "rustc-hash",
+ "rustversion",
+]
+
+[[package]]
+name = "mlua-sys"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f1c3a7fc7580227ece249fd90aa2fa3b39eb2b49d3aec5e103b3e85f2c3dfc8"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
+name = "mlua_derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465bddde514c4eb3b50b543250e97c1d4b284fa3ef7dc0ba2992c77545dbceb2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "nvim-oxi"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54489e0e1515ff8fdbd07eb198ac1f8b082b849e2ed3b7607d6705e24b74af5c"
+source = "git+https://github.com/noib3/nvim-oxi?rev=d411003cbe660cd32014806b2d1a04651b7d06e0#d411003cbe660cd32014806b2d1a04651b7d06e0"
 dependencies = [
  "cargo_metadata",
+ "mlua",
  "nvim-oxi-api",
  "nvim-oxi-luajit",
  "nvim-oxi-macros",
@@ -83,9 +192,9 @@ dependencies = [
 [[package]]
 name = "nvim-oxi-api"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a662cfeae9de93b4a6a1779e9e37e15c354f8f9acc933e2d79105d601c8fd4"
+source = "git+https://github.com/noib3/nvim-oxi?rev=d411003cbe660cd32014806b2d1a04651b7d06e0#d411003cbe660cd32014806b2d1a04651b7d06e0"
 dependencies = [
+ "mlua",
  "nvim-oxi-luajit",
  "nvim-oxi-macros",
  "nvim-oxi-types",
@@ -97,8 +206,7 @@ dependencies = [
 [[package]]
 name = "nvim-oxi-luajit"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bba46ec2ab57e840cd33067e0d1d7c89c2c7feafd02bbbb11a90a4220491a1c9"
+source = "git+https://github.com/noib3/nvim-oxi?rev=d411003cbe660cd32014806b2d1a04651b7d06e0#d411003cbe660cd32014806b2d1a04651b7d06e0"
 dependencies = [
  "thiserror",
 ]
@@ -106,8 +214,7 @@ dependencies = [
 [[package]]
 name = "nvim-oxi-macros"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c03daabc1d9efd2d5aff2746199b4ed60f2cc24c321d6fcb2aa023169b0f13"
+source = "git+https://github.com/noib3/nvim-oxi?rev=d411003cbe660cd32014806b2d1a04651b7d06e0#d411003cbe660cd32014806b2d1a04651b7d06e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -117,8 +224,7 @@ dependencies = [
 [[package]]
 name = "nvim-oxi-types"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f079f687853419cf83879ab060d23171e31689d090a0c8d5c6aa0e3210c83ec"
+source = "git+https://github.com/noib3/nvim-oxi?rev=d411003cbe660cd32014806b2d1a04651b7d06e0#d411003cbe660cd32014806b2d1a04651b7d06e0"
 dependencies = [
  "libc",
  "nvim-oxi-luajit",
@@ -146,6 +252,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,34 +299,66 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.19"
+name = "redox_syscall"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.25"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.218"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.218"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -200,14 +367,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -220,6 +388,18 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "syn"
@@ -257,3 +437,15 @@ name = "unicode-ident"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,14 @@ resolver = "2"
 nvim-winpick-core = { path = "./nvim-winpick-core/" }
 # External
 anyhow = "1.0.96"
-nvim-oxi = { version = "0.6.0", features = ["neovim-0-10", "neovim-0-11"] }
-serde = "1.0.218"
+nvim-oxi = { version = "0.6.0", features = ["neovim-0-11", "neovim-0-12"] }
+serde = "1.0.228"
 
 [workspace.lints.clippy]
 pedantic = {priority = -1, level = "warn"}
 module_name_repetitions = "allow"
 missing_errors_doc = "allow"
 similar_names = "allow"
+
+[patch.crates-io]
+nvim-oxi = { git = "https://github.com/noib3/nvim-oxi", rev = "d411003cbe660cd32014806b2d1a04651b7d06e0" }

--- a/nvim-winpick-core/src/filter.rs
+++ b/nvim-winpick-core/src/filter.rs
@@ -1,7 +1,8 @@
-use anyhow::Context;
-use nvim_oxi::api::Window;
-
 use crate::opts::FilterRules;
+use anyhow::Context;
+use nvim_oxi::api::opts::OptionOpts;
+use nvim_oxi::api::{get_option_value, Window};
+use std::path::Path;
 
 impl FilterRules {
     pub(crate) fn filter(&self, target_win: &Window, current_win: &Window) -> anyhow::Result<bool> {
@@ -23,24 +24,21 @@ impl FilterRules {
             || !self.bo.buftype.is_empty()
         {
             let buf = target_win.get_buf().context("failed to get window buf")?;
-            // Alternative is umapped in nvim_oxi so far
-            #[allow(deprecated)]
+
             if !self.bo.filetype.is_empty() {
-                let ft: Option<String> = buf
-                    .get_option("filetype")
-                    .context("failed to get buf filetype")?;
+                let ft: Option<String> =
+                    get_option_value("filetype", &OptionOpts::builder().buf(buf.clone()).build())
+                        .context("failed to get buf filetype")?;
                 if let Some(ft) = ft {
                     if self.bo.filetype.iter().any(|filter_ft| filter_ft == &ft) {
                         return Ok(false);
                     }
                 }
             }
-            // Alternative is unmapped in nvim_oxi so far
-            #[allow(deprecated)]
             if !self.bo.buftype.is_empty() {
-                let bt: Option<String> = buf
-                    .get_option("buftype")
-                    .context("failed to get buf buftype")?;
+                let bt: Option<String> =
+                    get_option_value("buftype", &OptionOpts::builder().buf(buf.clone()).build())
+                        .context("failed to get buf buftype")?;
                 if let Some(ft) = bt {
                     if self.bo.buftype.iter().any(|filter_ft| filter_ft == &ft) {
                         return Ok(false);
@@ -49,7 +47,7 @@ impl FilterRules {
             }
             if !self.file_name_contains.is_empty() || !self.file_path_contains.is_empty() {
                 let buf_file = buf.get_name().context("failed to get buf file")?;
-                let path_utf8 = buf_file.display().to_string();
+                let path_utf8 = buf_file.to_string();
                 if self
                     .file_path_contains
                     .iter()
@@ -58,7 +56,7 @@ impl FilterRules {
                     return Ok(false);
                 }
                 if !self.file_name_contains.is_empty() {
-                    if let Some(file_name) = buf_file.file_name() {
+                    if let Some(file_name) = Path::new(&path_utf8).file_name() {
                         if let Some(utf8) = file_name.to_str() {
                             if self.file_name_contains.iter().any(|f| utf8.contains(f)) {
                                 return Ok(false);

--- a/nvim-winpick-core/src/notify.rs
+++ b/nvim-winpick-core/src/notify.rs
@@ -1,17 +1,13 @@
-use nvim_oxi::Dictionary;
+use nvim_oxi::api::opts::EchoOpts;
 
 pub(crate) fn notify_error(msg: &str) {
-    let _ = nvim_oxi::api::notify(
-        msg,
-        nvim_oxi::api::types::LogLevel::Error,
-        &Dictionary::default(),
+    let _ = nvim_oxi::api::echo(
+        [(msg, None::<&str>)],
+        true,
+        &EchoOpts::builder().err(true).build(),
     );
 }
 
 pub(crate) fn notify_warn(msg: &str) {
-    let _ = nvim_oxi::api::notify(
-        msg,
-        nvim_oxi::api::types::LogLevel::Warn,
-        &Dictionary::default(),
-    );
+    let _ = nvim_oxi::api::echo([(msg, None::<&str>)], true, &EchoOpts::default());
 }


### PR DESCRIPTION
fixes https://github.com/MarcusGrass/nvim_winpick/issues/7
Breaks with neovim 0.11 because of changes to `echo`. Theoretically this wouldn't have to break (with a crash), but I don't feel like figuring out the nvim version at runtime